### PR TITLE
Networking pronto

### DIFF
--- a/networking/networking.gd
+++ b/networking/networking.gd
@@ -4,6 +4,9 @@ extends Node
 signal connection_fail()
 signal peer_disconnected()
 signal game_finished()
+signal ready_start()
+signal start_game()
+signal direction_warning(direction)
 
 # Enum for directions for warnings
 # Should probably move it out of here
@@ -60,17 +63,17 @@ remote func update_postion(pos_x, pos_y):
 # The audio client calls this on the server to send a warning
 # Use DIR(ection) enum
 remote func send_warning(direction):
-	pass
+	emit_signal("direction_warning", direction)
 	
 # Client tells server that it's ready for the match
 # Will will wait for "start_match" from the server
 remote func ready_to_start():
-	pass
+	emit_signal("ready_start")
 
 # Server tells client to start the match
 # Should wait for "ready_to_start" if hasn't received it yet
 remote func start_game():
-	pass
+	emit_signal("start_game")
 	
 # Server tells client to end the game because it won
 remote func game_win():

--- a/networking/networking.gd
+++ b/networking/networking.gd
@@ -18,10 +18,16 @@ enum DIR {
 	DOWN_RIGHT
 }
 
-# Join a host (visual client)
+# Join a host (for audio client use)
 func join_game(ip : String, port : int):
 	var server = NetworkedMultiplayerENet.new()
 	server.create_client(ip, port)
+	get_tree().set_networked_peer(server)
+
+# Host a game (for visual client use)
+func host_game(port : int):
+	var server = NetworkedMultiplayerENet.new()
+	server.create_server(port, 2) # Max 2 players
 	get_tree().set_networked_peer(server)
 
 func _ready():
@@ -69,6 +75,7 @@ remote func start_game():
 # Server tells client to end the game because it won
 remote func game_win():
 	emit_signal("game_finished")
+	get_tree().set_network_peer(null)
 	
 # Call when you want to quit the game
 # Tells the other peer you disconnected automagically

--- a/networking/networking.gd
+++ b/networking/networking.gd
@@ -7,6 +7,7 @@ signal peer_disconnected()
 signal game_finished()
 signal ready_start()
 signal start_game()
+signal connected()
 
 # In game communication
 signal direction_warning(direction)
@@ -45,12 +46,13 @@ func _ready():
 	get_tree().connect("connection_failed", self, "_connected_fail")
 	get_tree().connect("server_disconnected", self, "_peer_disconnected")
 	
-
+# Since it's only one server and one client, no need to warn other peers that connection happened,
+# so just pass the signal up for the interface to handle
 func _player_connected(id):
-	pass
+	emit_signal("connected")
 
 func _connected_ok():
-	pass
+	emit_signal("connected")
 
 func _connected_fail():
 	get_tree().set_network_peer(null)

--- a/networking/networking.gd
+++ b/networking/networking.gd
@@ -1,12 +1,16 @@
 extends Node
 
-# Signals for the main game
+# Signals 
+# For pre-game
 signal connection_fail()
 signal peer_disconnected()
 signal game_finished()
 signal ready_start()
 signal start_game()
+
+# In game communication
 signal direction_warning(direction)
+signal new_postion(position)
 
 # Enum for directions for warnings
 # Should probably move it out of here
@@ -57,8 +61,8 @@ func _peer_disconnected():
 	emit_signal("peer_disconnected")
 
 # The server calls this function to update the player position on the audio client 
-remote func update_postion(pos_x, pos_y):
-	pass
+remote func update_postion(pos : Vector2):
+	emit_signal("new_postion", pos)
 	
 # The audio client calls this on the server to send a warning
 # Use DIR(ection) enum


### PR DESCRIPTION
Networking bem básico, muitos sinais na verdade, só abstração. Talvez seja bom tirar o enum de direções dali, mas pode ser feito depois.

Agora da pra [carregar como um singleton](https://docs.godotengine.org/en/3.1/getting_started/step_by_step/singletons_autoload.html) e só usar no resto do código.